### PR TITLE
Staging/test branches

### DIFF
--- a/.github/workflows/deploy-staging-branch.yml
+++ b/.github/workflows/deploy-staging-branch.yml
@@ -1,0 +1,80 @@
+name: Deploy to staging remote server on a distinct developer branch
+
+on:
+  push:
+    branches:
+      - staging/**
+
+jobs:
+  get-environment-variables:
+    runs-on: ubuntu-latest
+    outputs:
+      staging_name: ${{ steps.set_subdomain.outputs.staging_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Retrieve subdomain from branch
+        id: set_subdomain
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}      
+          STAGING_NAME=$(echo "${BRANCH_NAME}" | sed 's/staging\///g')
+
+          echo "staging_name=${STAGING_NAME}" >> $GITHUB_OUTPUT
+  deploy:
+    name: Build and deploy to staging branch
+    needs:
+      - get-environment-variables
+
+    runs-on: ubuntu-latest
+    env:
+      STAGING_NAME: ${{needs.get-environment-variables.outputs.staging_name}}
+      STAGING_DIRECTORY: ${{format('{0}{1}', secrets.SSH_STAGING_ROOT_PATH, needs.get-environment-variables.outputs.staging_name)}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push docker images with compose
+        run: |
+          printf "\nSTAGING_NAME=${STAGING_NAME}\n" >> .default.env
+ 
+
+          docker compose -f docker-compose.prod.yml --env-file .default.env build
+          docker compose -f docker-compose.prod.yml --env-file .default.env push
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{secrets.SSH_PRIVATE_KEY}}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -p ${{secrets.SSH_PORT}} ${{ secrets.SSH_REMOTE_IP}} >> ~/.ssh/known_hosts
+
+      - name: Install rsync
+        run: sudo apt-get install -y rsync
+
+      - name: Deploy via rsync
+        run: |
+
+          rsync -avz --rsync-path="mkdir -p ${STAGING_DIRECTORY} && rsync" --no-times --no-perms --no-group -e "ssh -p ${{ secrets.SSH_PORT }} -o StrictHostKeyChecking=no" docker-compose.deploy.yml .default.env ${{secrets.SSH_USER}}@${{secrets.SSH_REMOTE_IP}}:${STAGING_DIRECTORY}
+
+      - name: Rebuild containers
+        run: |
+          ssh -o StrictHostKeyChecking=no -p ${{secrets.SSH_PORT}} ${{secrets.SSH_USER}}@${{secrets.SSH_REMOTE_IP}} << EOF
+          cd ${{env.STAGING_DIRECTORY}}    
+                              
+
+          echo "${{secrets.DOCKERHUB_TOKEN}}" | docker login -u "${{secrets.DOCKERHUB_USERNAME}}" --password-stdin
+          docker compose -f docker-compose.deploy.yml down --rmi all -v  || true
+
+          docker compose -f docker-compose.deploy.yml --env-file .default.env  build
+          docker compose -f docker-compose.deploy.yml --env-file .default.env  up -d
+          docker compose -f docker-compose.deploy.yml --env-file .default.env exec products-api dotnet console/Backend.Core.Console.dll --update-db
+          docker compose -f docker-compose.deploy.yml --env-file .default.env exec products-api dotnet console/Backend.Core.Console.dll --fetch
+
+          docker system prune -f

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,4 +1,4 @@
-name: Deploy to remove server
+name: Deploy to staging remove server
 
 on:
     push:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -8,14 +8,14 @@ x-common-env-config: &env-config
 services:
   products:
     <<: *env-config
-    image: sercudo/frontend-products-image-prod:latest
-    hostname: ${SERVICE_HOST:-products}
+    image: sercudo/frontend-products-image-prod:${STAGING_NAME:-latest}
+    hostname: ${STAGING_NAME:-products}
     networks:
       - proxy_network    
       - default_products_deployment_network        
   products-frontend-next:
     <<: *env-config       
-    image: sercudo/frontend-next-products-image-prod:latest
+    image: sercudo/frontend-next-products-image-prod:${STAGING_NAME:-latest}
 
     networks:
       - default_products_deployment_network
@@ -25,7 +25,7 @@ services:
 
   products-api:
     <<: *env-config      
-    image: sercudo/api-products-image-prod:latest
+    image: sercudo/api-products-image-prod:${STAGING_NAME:-latest}
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
     restart: unless-stopped
@@ -35,7 +35,7 @@ services:
 
   products-postgres:
     <<: *env-config      
-    image: sercudo/postgres-products-image-prod:latest
+    image: sercudo/postgres-products-image-prod:${STAGING_NAME:-latest}
     networks:
       - default_products_deployment_network
 
@@ -44,6 +44,6 @@ services:
 
 networks:
   default_products_deployment_network:
-    name: products_deployment_network
+    name: ${STAGING_NAME:-products_deployment_network}
   proxy_network:
     external: true


### PR DESCRIPTION
Implement extra staging multi branch environment.
Configuration allows developers to create staging branches with distinct names which correspond 
to isolated contenerized environments on the remote server.  
A git push to staging/test-branches create a `test-branches` subdomain with entire isolated environment.
This allow developers utilize staging environments to the core without colliding with each other.
